### PR TITLE
Update __init__.py

### DIFF
--- a/pypoloniex/__init__.py
+++ b/pypoloniex/__init__.py
@@ -1,2 +1,2 @@
-from LoadPairs import LoadPairs
-from TimeSeries import TimeSeries
+from .LoadPairs import LoadPairs
+from .TimeSeries import TimeSeries


### PR DESCRIPTION
>"In Python 3, implicit relative imports within packages are no longer available - only absolute imports and explicit relative imports are supported."

changed the import statements in \__init\__ to explicit relative imports